### PR TITLE
Update jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
   or use the cdn provided by jsdelivr.net (replace "x.y.z" with the real version number):
 
-    `<script src="http://cdn.jsdelivr.net/domcom/x.y.z/domcom.min.js"/>`
+    `<script src="https://cdn.jsdelivr.net/npm/domcom@x.y.z/lib/domcom.min.js"/>`
 
 ## Features
 * declarative composable components with reactive function


### PR DESCRIPTION
[jsDelivr switched to a fully automated system](https://www.jsdelivr.com/features), that can serve files from npm and GitHub. This means all future releases will be available automatically, but will use a new link structure.

I updated the link now so you don't forget to do it when you release a new version.

You can find links for all files at https://www.jsdelivr.com/package/npm/domcom.

Feel free to ping me if you have any questions regarding this change.